### PR TITLE
Fix out of range error

### DIFF
--- a/src/PCAPNGParser.js
+++ b/src/PCAPNGParser.js
@@ -132,7 +132,7 @@ class PCAPNGParser extends Transform {
         let pos = 0
         let foundEndOption = false
         let options = []
-        while (pos <= buf.length || foundEndOption) {
+        while (pos < buf.length || foundEndOption) {
             let rb = this.readBlock(buf, BlockConfig.optionBlock, this.endianess, pos)
             pos = rb.newOffset + (rb.data.dataLength * 8)
             if (rb.data.code === 0) {


### PR DESCRIPTION
This pull request fixes a bug when reading the options of a PCAPNG block, as it would try to read out of bounds when the position is equal to the buffer length.

Closes #1